### PR TITLE
Replacing all instances of "server-host-override" with "serverhostoverride" 

### DIFF
--- a/events/consumer/consumer.go
+++ b/events/consumer/consumer.go
@@ -53,8 +53,8 @@ func newOpenchainEventsClientConnectionWithAddress(peerAddress string) (*grpc.Cl
 	var opts []grpc.DialOption
 	if viper.GetBool("peer.tls.enabled") {
 		var sn string
-		if viper.GetString("peer.tls.server-host-override") != "" {
-			sn = viper.GetString("peer.tls.server-host-override")
+		if viper.GetString("peer.tls.serverhostoverride") != "" {
+			sn = viper.GetString("peer.tls.serverhostoverride")
 		}
 		var creds credentials.TransportAuthenticator
 		if viper.GetString("peer.tls.cert.file") != "" {

--- a/obc-ca/obcca.yaml
+++ b/obc-ca/obcca.yaml
@@ -87,5 +87,5 @@ pki:
                          key:
                                 file: testdata/server1.key
                          # The server name use to verify the hostname returned by TLS handshake
-                         server-host-override:
+                         serverhostoverride:
                  devops-address: 0.0.0.0:30303

--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -136,7 +136,7 @@ peer:
         key:
             file: testdata/server1.key
         # The server name use to verify the hostname returned by TLS handshake
-        server-host-override:
+        serverhostoverride:
 
     # PKI member services properties
     pki:
@@ -209,7 +209,7 @@ validator:
         key:
             file: testdata/server1.key
         # The server name use to verify the hostname returned by TLS handshake
-        server-host-override:
+        serverhostoverride:
     # Peer discovery settings.  Controls how this peer discovers other peers
     discovery:
 

--- a/obc-ca/obcca/validity_period.go
+++ b/obc-ca/obcca/validity_period.go
@@ -79,8 +79,8 @@ func getDevopsClient(peerAddress string) (obc.DevopsClient, error) {
 	var opts []grpc.DialOption
 	if viper.GetBool("pki.validity-period.tls.enabled") {
 		var sn string
-		if viper.GetString("pki.validity-period.tls.server-host-override") != "" {
-			sn = viper.GetString("pki.validity-period.tls.server-host-override")
+		if viper.GetString("pki.validity-period.tls.serverhostoverride") != "" {
+			sn = viper.GetString("pki.validity-period.tls.serverhostoverride")
 		}
 		var creds credentials.TransportAuthenticator
 		if viper.GetString("pki.validity-period.tls.cert.file") != "" {

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -192,7 +192,7 @@ peer:
             rootcert:
                 file: tlsca.cert
             # The server name use to verify the hostname returned by TLS handshake
-            server-host-override:
+            serverhostoverride:
 
     # Peer discovery settings.  Controls how this peer discovers other peers
     discovery:

--- a/openchain/chaincode/shim/chaincode.go
+++ b/openchain/chaincode/shim/chaincode.go
@@ -109,8 +109,8 @@ func newPeerClientConnection() (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 	if viper.GetBool("peer.tls.enabled") {
 		var sn string
-		if viper.GetString("peer.tls.server-host-override") != "" {
-			sn = viper.GetString("peer.tls.server-host-override")
+		if viper.GetString("peer.tls.serverhostoverride") != "" {
+			sn = viper.GetString("peer.tls.serverhostoverride")
 		}
 		var creds credentials.TransportAuthenticator
 		if viper.GetString("peer.tls.cert.file") != "" {

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -68,7 +68,7 @@ peer:
             rootcert:
 
             # The server name use to verify the hostname returned by TLS handshake
-            server-host-override:
+            serverhostoverride:
 
     validator:
         enabled: false

--- a/openchain/crypto/node_conf.go
+++ b/openchain/crypto/node_conf.go
@@ -114,8 +114,8 @@ func (conf *configuration) init() error {
 
 	// Set TLS host override
 	conf.tlsServerName = "tlsca"
-	if viper.IsSet("peer.pki.tls.server-host-override") {
-		ovveride := viper.GetString("peer.pki.tls.server-host-override")
+	if viper.IsSet("peer.pki.tls.serverhostoverride") {
+		ovveride := viper.GetString("peer.pki.tls.serverhostoverride")
 		if ovveride != "" {
 			conf.tlsServerName = ovveride
 		}

--- a/openchain/ledger/genesis/genesis_test.yaml
+++ b/openchain/ledger/genesis/genesis_test.yaml
@@ -95,7 +95,7 @@ peer:
         key:
             file: testdata/server1.key
         # The server name use to verify the hostname returned by TLS handshake
-        server-host-override:
+        serverhostoverride:
 
     # Peer discovery settings.  Controls how this peer discovers other peers
     discovery:
@@ -159,7 +159,7 @@ validator:
         key:
             file: testdata/server1.key
         # The server name use to verify the hostname returned by TLS handshake
-        server-host-override:
+        serverhostoverride:
     # Peer discovery settings.  Controls how this peer discovers other peers
     discovery:
 

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -179,8 +179,8 @@ func NewPeerClientConnectionWithAddress(peerAddress string) (*grpc.ClientConn, e
 	var opts []grpc.DialOption
 	if viper.GetBool("peer.tls.enabled") {
 		var sn string
-		if viper.GetString("peer.tls.server-host-override") != "" {
-			sn = viper.GetString("peer.tls.server-host-override")
+		if viper.GetString("peer.tls.serverhostoverride") != "" {
+			sn = viper.GetString("peer.tls.serverhostoverride")
 		}
 		var creds credentials.TransportAuthenticator
 		if viper.GetString("peer.tls.cert.file") != "" {


### PR DESCRIPTION
as we cannot use hyphens in environment variables.

We can use OPENCHAIN_PEER_TLS_SERVERHOSTOVERRIDE instead of
OPENCHAIN_PEER_TLS_SERVER-HOST-OVERRIDE